### PR TITLE
Fix test failures due to '.' removal from @INC under Perl 5.26

### DIFF
--- a/t/carp.pl
+++ b/t/carp.pl
@@ -14,10 +14,10 @@
 
 print "1..11\n";
 
-require 't/code.pl';
+require './t/code.pl';
 sub ok;
 
-my $FILE = "t/carp.pl";
+my $FILE = "./t/carp.pl";
 
 package OTHER;
 use Log::Agent;

--- a/t/carp_default.t
+++ b/t/carp_default.t
@@ -20,4 +20,4 @@ select(ORIG_STDOUT);
 open(STDOUT, ">t/file.out") || die "can't redirect STDOUT: $!\n";
 open(STDERR, ">t/file.err") || die "can't redirect STDOUT: $!\n";
 
-do 't/carp.pl';
+do './t/carp.pl';

--- a/t/carp_file.t
+++ b/t/carp_file.t
@@ -27,4 +27,4 @@ my $driver = Log::Agent::Driver::File->make(
 );
 logconfig(-driver => $driver);
 
-do 't/carp.pl';
+do './t/carp.pl';

--- a/t/carp_fork.t
+++ b/t/carp_fork.t
@@ -29,4 +29,4 @@ my $driver = Log::Agent::Driver::Fork->make(
 );
 logconfig(-driver => $driver);
 
-do 't/carp.pl';
+do './t/carp.pl';

--- a/t/default.t
+++ b/t/default.t
@@ -14,7 +14,7 @@
 
 print "1..4\n";
 
-require 't/code.pl';
+require './t/code.pl';
 sub ok;
 
 use Log::Agent;

--- a/t/default_exp.t
+++ b/t/default_exp.t
@@ -19,7 +19,7 @@
 
 print "1..8\n";
 
-require 't/code.pl';
+require './t/code.pl';
 sub ok;
 
 use Log::Agent;

--- a/t/file.t
+++ b/t/file.t
@@ -15,7 +15,7 @@
 use Test::More;
 use Log::Agent;
 require Log::Agent::Driver::File;
-require 't/common.pl';
+require './t/common.pl';
 
 BEGIN { plan tests => 38 }
 

--- a/t/fork.t
+++ b/t/fork.t
@@ -14,7 +14,7 @@
 
 use strict;
 use Test;
-require 't/common.pl';
+require './t/common.pl';
 
 BEGIN { plan tests => 19 }
 

--- a/t/priority.t
+++ b/t/priority.t
@@ -14,7 +14,7 @@
 
 print "1..5\n";
 
-require 't/code.pl';
+require './t/code.pl';
 sub ok;
 
 use Log::Agent;

--- a/t/tag_callback.t
+++ b/t/tag_callback.t
@@ -12,7 +12,7 @@
 #
 ##########################################################################
 
-require 't/code.pl';
+require './t/code.pl';
 sub ok;
 
 eval "require Callback";

--- a/t/tag_string.t
+++ b/t/tag_string.t
@@ -14,7 +14,7 @@
 
 print "1..2\n";
 
-require 't/code.pl';
+require './t/code.pl';
 sub ok;
 
 use Log::Agent;


### PR DESCRIPTION
when PERL_USE_UNSAFE_INC=0

Bug: https://bugs.gentoo.org/617050
Bug: https://rt.cpan.org/Ticket/Display.html?id=121459