### PR TITLE
Add missing logcluck().

### DIFF
--- a/Agent.pm
+++ b/Agent.pm
@@ -26,7 +26,7 @@ use vars qw(@ISA @EXPORT @EXPORT_OK);
 @ISA = qw(Exporter);
 @EXPORT = qw(
 	logconfig
-	logconfess logcroak logcarp logxcroak logxcarp
+	logconfess logcluck logcroak logcarp logxcroak logxcarp
 	logsay logerr logwarn logdie logtrc logdbg
 );
 @EXPORT_OK = qw(
@@ -310,6 +310,19 @@ sub logxcarp {
 }
 
 #
+# logcluck
+#
+# Warning, with a full stack trace.
+#
+sub logcluck {
+	return if $Trace < WARN;
+	my $ptag = prio_tag(priority_level(WARN)) if defined $Priorities;
+	my $str = tag_format_args($Caller, $ptag, $Tags, \@_);
+	&log_default unless defined $Driver;
+	$Driver->logcluck($str);
+}
+
+#
 # logwarn
 #
 # Log warning at the "warning" level.
@@ -573,6 +586,10 @@ Log a warning message at the C<warning> priority to the C<error> channel.
 
 Same as logwarn(), but issues a Carp::carp(3) call instead, which will
 warn from the perspective of the routine's caller.
+
+=item logcluck I<message>
+
+Same as logwarn(), but dumps a full stacktrace as well.
 
 =item logerr I<message>
 

--- a/Agent/Driver/Datum.pm
+++ b/Agent/Driver/Datum.pm
@@ -116,6 +116,7 @@ sub logconfess	{ intercept(\@_, '**', 'logconfess', 'error',	'FATAL') }
 sub logxcroak	{ intercept(\@_, '**', 'logxcroak',	 'error',	'FATAL') }
 sub logdie		{ intercept(\@_, '**', 'logdie',	 'error',	'FATAL') }
 sub logerr		{ intercept(\@_, '>>', 'logerr',	 'error',	'ERROR') }
+sub logcluck	{ intercept(\@_, '>>', 'logcluck',	 'error',	'WARNING') }
 sub logwarn		{ intercept(\@_, '>>', 'logwarn',	 'error',	'WARNING') }
 sub logxcarp	{ intercept(\@_, '>>', 'logxcarp',	 'error',	'WARNING') }
 sub logsay		{ intercept(\@_, '>>', 'logsay',	 'output') }

--- a/Agent/Driver/Default.pm
+++ b/Agent/Driver/Default.pm
@@ -82,6 +82,19 @@ sub logconfess {
 }
 
 #
+# ->logcluck		-- redefined
+#
+# Warning, with stack trace
+#
+sub logcluck {
+	my $self = shift;
+	my ($str) = @_;
+	require Carp;
+	my $msg = $self->carpmess(0, $str, \&Carp::longmess);
+	warn $self->prefix_msg("$msg\n");
+}
+
+#
 # ->logxcroak		-- redefined
 #
 # Fatal error, from perspective of caller

--- a/Agent/Driver/File.pm
+++ b/Agent/Driver/File.pm
@@ -363,6 +363,19 @@ sub logerr {
 }
 
 #
+# ->logcluck
+#
+# When `duperr' is true, emit message on the 'output' channel prefixed
+# with WARNING.
+#
+sub logconfess {
+    my $self = shift;
+    my ($str) = @_;
+    $self->emit_output('warning', "WARNING", $str) if $self->duperr;
+    $self->SUPER::logcluck($str);    # Carp strips calls within hierarchy
+}
+
+#
 # ->logwarn
 #
 # When `duperr' is true, emit message on the 'output' channel prefixed

--- a/Agent/Driver/Fork.pm
+++ b/Agent/Driver/Fork.pm
@@ -232,6 +232,18 @@ sub logwarn {
 }
 
 #
+# logcluck
+#
+# Warning, with stack trace
+#
+sub logcluck {
+    my($self, $str) = @_;
+
+    # log error to all drivers
+    $self->emit_carp('error', 'warning', 0, $str);
+}
+
+#
 # logcarp
 #
 # log a warning, carp-style

--- a/Agent/Driver/Silent.pm
+++ b/Agent/Driver/Silent.pm
@@ -46,6 +46,7 @@ sub channel_eq { 1 }
 
 sub logerr {}
 sub logwarn {}
+sub logcluck {}
 sub logsay {}
 sub logwrite {}
 sub logxcarp {}


### PR DESCRIPTION
This warns like logwarn() does, but it also emits a full stack
trace, which will help determine the dynamics leading to that
not-so-ideal condition.