### PR TITLE
Adding loginfo() and logdebug().

### DIFF
--- a/Agent.pm
+++ b/Agent.pm
@@ -27,7 +27,7 @@ use vars qw(@ISA @EXPORT @EXPORT_OK);
 @EXPORT = qw(
 	logconfig
 	logconfess logcluck logcroak logcarp logxcroak logxcarp
-	logsay logerr logwarn logdie logtrc logdbg
+	logdebug loginfo logsay logerr logwarn logdie logtrc logdbg
 );
 @EXPORT_OK = qw(
 	logwrite logtags
@@ -348,6 +348,30 @@ sub logsay {
 	$Driver->logsay($str);
 }
 
+# loginfo
+#
+# Log message at the "info" level.
+#
+sub loginfo {
+	return if $Trace < INFO;
+	my $ptag = prio_tag(priority_level(INFO)) if defined $Priorities;
+	my $str = tag_format_args($Caller, $ptag, $Tags, \@_);
+	&log_default unless defined $Driver;
+	$Driver->loginfo($str);
+}
+
+# logdebug
+#
+# Log message at the "debug" level.
+#
+sub logdebug {
+	return if $Trace < DEBUG;
+	my $ptag = prio_tag(priority_level(INFO)) if defined $Priorities;
+	my $str = tag_format_args($Caller, $ptag, $Tags, \@_);
+	&log_default unless defined $Driver;
+	$Driver->logdebug($str);
+}
+
 #
 # logtrc		-- frozen
 #
@@ -565,6 +589,17 @@ Trace logging of I<message> to the C<output> channel.
 Like logdbg() above, you are not restricted to the C<info> priority. This
 routine checks the logging level (either explicit as in C<"info:14">
 or implicit as in C<"notice">) against the trace level.
+
+=item logdebug I<message>
+
+Log the message at the C<debug> priority to the C<output> channel.
+
+The difference with logdbg() is twofold: logging is done on the
+C<output> channel, not the C<debug> one, and the priority is implicit.
+
+=item loginfo I<message>
+
+Log the message at the C<info> priority to the C<output> channel.
 
 =item logsay I<message>
 

--- a/Agent/Driver.pm
+++ b/Agent/Driver.pm
@@ -350,6 +350,28 @@ sub logsay {
 }
 
 #
+# loginfo
+#
+# Log message at the "info" level.
+#
+sub loginfo {
+    my $self = shift;
+    my ($str) = @_;
+    $self->emit('output', 'info', $str);
+}
+
+#
+# logdebug
+#
+# Log message at the "debug" level.
+#
+sub logdebug {
+    my $self = shift;
+    my ($str) = @_;
+    $self->emit('output', 'debug', $str);
+}
+
+#
 # logwrite
 #
 # Emit the message to the specified channel

--- a/Agent/Driver/Datum.pm
+++ b/Agent/Driver/Datum.pm
@@ -120,6 +120,8 @@ sub logcluck	{ intercept(\@_, '>>', 'logcluck',	 'error',	'WARNING') }
 sub logwarn		{ intercept(\@_, '>>', 'logwarn',	 'error',	'WARNING') }
 sub logxcarp	{ intercept(\@_, '>>', 'logxcarp',	 'error',	'WARNING') }
 sub logsay		{ intercept(\@_, '>>', 'logsay',	 'output') }
+sub loginfo		{ intercept(\@_, '>>', 'loginfo',	 'output') }
+sub logdebug	{ intercept(\@_, '>>', 'logdebug',	 'output') }
 
 #
 # logwrite		-- redefined

--- a/Agent/Driver/Fork.pm
+++ b/Agent/Driver/Fork.pm
@@ -285,6 +285,34 @@ sub logsay {
     $self->emit('output', 'notice', $str);
 }
 
+#
+# loginfo
+#
+# Log message to "output" channel at "info" priority
+#
+sub loginfo {
+    my($self, $str) = @_;
+
+    #
+    # send message to drivers
+    #
+    $self->emit('output', 'info', $str);
+}
+
+#
+# logdebug
+#
+# Log message to "output" channel at "debug" priority
+#
+sub logdebug {
+    my($self, $str) = @_;
+
+    #
+    # send message to drivers
+    #
+    $self->emit('output', 'debug', $str);
+}
+
 1;  # for require
 __END__
 

--- a/Agent/Driver/Silent.pm
+++ b/Agent/Driver/Silent.pm
@@ -44,10 +44,12 @@ sub channel_eq { 1 }
 # routines would not do anything. Let's redefine them though...
 #
 
-sub logerr {}
-sub logwarn {}
+sub logerr   {}
+sub logwarn  {}
 sub logcluck {}
-sub logsay {}
+sub logsay   {}
+sub loginfo  {}
+sub logdebug {}
 sub logwrite {}
 sub logxcarp {}
 

--- a/t/default.t
+++ b/t/default.t
@@ -12,7 +12,7 @@
 #
 ##########################################################################
 
-print "1..4\n";
+print "1..6\n";
 
 require './t/code.pl';
 sub ok;
@@ -27,6 +27,8 @@ open(STDERR, ">t/default.err") || die "can't redirect STDERR: $!\n";
 
 logerr "error";
 logsay "message";
+loginfo "info";
+logdebug "debugging";
 logtrc 'debug', "debug";
 
 close STDOUT;
@@ -35,6 +37,8 @@ close STDERR;
 ok 1, contains("t/default.err", '^Error$');
 ok 2, contains("t/default.err", '^Message$');
 ok 3, !contains("t/default.err", '^Debug$');
-ok 4, 0 == -s "t/default.out";
+ok 4, !contains("t/default.err", '^Debugging$');
+ok 5, !contains("t/default.err", '^Info$');
+ok 6, 0 == -s "t/default.out";
 
 unlink 't/default.out', 't/default.err';

--- a/t/file.t
+++ b/t/file.t
@@ -14,10 +14,11 @@
 
 use Test::More;
 use Log::Agent;
+use Log::Agent::Priorities qw(:LEVELS);
 require Log::Agent::Driver::File;
 require './t/common.pl';
 
-BEGIN { plan tests => 38 }
+BEGIN { plan tests => 42 }
 
 my $driver = Log::Agent::Driver::File->make();        # take all defaults
 logconfig(-driver => $driver);
@@ -55,7 +56,7 @@ $driver = Log::Agent::Driver::File->make(
     },
     -duperr => 1,
 );
-logconfig(-driver => $driver);
+logconfig(-driver => $driver, -level => DEBUG);
 
 open(ORIGOUT, ">&STDOUT")   or die "can't dup STDOUT: $!\n";
 open(STDOUT, ">t/file.out") or die "can't redirect STDOUT: $!\n";
@@ -65,6 +66,8 @@ select(ORIGERR); $| = 1;
 select(ORIGOUT); $| = 1;
 
 logerr "error";
+logdebug "debug";
+loginfo "info";
 logsay "message";
 logwarn "warning";
 eval { logdie "die" };
@@ -80,7 +83,11 @@ ok($@);
 ok(contains("t/file.err", '^DATE me\[\d+\]: error$'));
 ok(contains("t/file.out", 'ERROR: error'));
 ok(contains("t/file.out", '^DATE me\[\d+\]: message$'));
+ok(contains("t/file.out", '^DATE me\[\d+\]: info$'));
+ok(contains("t/file.out", '^DATE me\[\d+\]: debug$'));
 ok(! contains("t/file.err", 'message'));
+ok(! contains("t/file.err", 'info'));
+ok(! contains("t/file.err", 'debug'));
 ok(contains("t/file.err", '^DATE me\[\d+\]: warning$'));
 ok(contains("t/file.out", 'WARNING: warning'));
 ok(contains("t/file.err", '^DATE me\[\d+\]: die$'));

--- a/t/priority.t
+++ b/t/priority.t
@@ -12,7 +12,7 @@
 #
 ##########################################################################
 
-print "1..5\n";
+print "1..7\n";
 
 require './t/code.pl';
 sub ok;
@@ -39,11 +39,14 @@ logerr "error string";
 logsay "notice string";
 logcarp "carp string";
 logdbg 'info:12', "info string";
+logdebug "debug string in out";
 
 ok 1, contains("t/file.err", "<error/3> error string");
 ok 2, !contains("t/file.err", "notice string");
 ok 3, contains("t/file.err", "<warning/4> carp string");
 ok 4, contains("t/file.out", "<notice/6> notice string");
 ok 5, contains("t/file.err", "<info/12> info string");
+ok 6, !contains("t/file.err", "debug string in out");
+ok 7, contains("t/file.out", "debug string in out");
 
 unlink 't/file.out', 't/file.err';


### PR DESCRIPTION
The loginfo() and logdebug() calls were missing.  By default they don't emit anything, unless the default logging level is raised from NOTICE to INFO or DEBUG.