### PR TITLE
Define logcluck properly.

### DIFF
--- a/Agent/Driver/File.pm
+++ b/Agent/Driver/File.pm
@@ -368,7 +368,7 @@ sub logerr {
 # When `duperr' is true, emit message on the 'output' channel prefixed
 # with WARNING.
 #
-sub logconfess {
+sub logcluck {
     my $self = shift;
     my ($str) = @_;
     $self->emit_output('warning', "WARNING", $str) if $self->duperr;


### PR DESCRIPTION
Due to copy-n-paste error, was simply redefining logconfess instead
of defining logcluck.